### PR TITLE
Added missing return value for copy constructor - prevent crashing

### DIFF
--- a/lef/lefiLayer.cpp
+++ b/lef/lefiLayer.cpp
@@ -952,6 +952,7 @@ LEF_ASSIGN_OPERATOR_C( lefiOrthogonal ) {
     LEF_COPY_FUNC( numCutOrtho_ );
     LEF_MALLOC_FUNC( cutWithin_, double, sizeof(double) * numCutOrtho_ );
     LEF_MALLOC_FUNC( ortho_, double, sizeof(double) * numCutOrtho_ ); 
+    return *this;
 }
 
 

--- a/lef/lefiMacro.cpp
+++ b/lef/lefiMacro.cpp
@@ -61,6 +61,7 @@ LEF_COPY_CONSTRUCTOR_C( lefiObstruction )
 
 LEF_ASSIGN_OPERATOR_C ( lefiObstruction ) {
     LEF_MALLOC_FUNC( geometries_, lefiGeometries, sizeof(lefiGeometries)* 1 );
+    return *this;
 }
 
 
@@ -254,6 +255,7 @@ LEF_ASSIGN_OPERATOR_C( lefiPinAntennaModel ) {
     LEF_MALLOC_FUNC( antennaMaxCutCar_, double, sizeof(double) * numAntennaMaxCutCar_);
     // !!
     LEF_MALLOC_FUNC_FOR_2D_STR( antennaMaxCutCarLayer_, numAntennaMaxCutCar_ );
+    return *this;
 }
 
 lefiPinAntennaModel::~lefiPinAntennaModel()

--- a/lef/lefiUnits.cpp
+++ b/lef/lefiUnits.cpp
@@ -108,6 +108,7 @@ LEF_ASSIGN_OPERATOR_C( lefiUnits ) {
     LEF_COPY_FUNC( current_ );
     LEF_COPY_FUNC( voltage_ );
     LEF_COPY_FUNC( frequency_ );
+    return *this;
 }
 
 void


### PR DESCRIPTION
Missing return value in copy constructor does not behave well in gcc 9.1.0