### PR TITLE
Remove optimization flags from lef/def parsers

### DIFF
--- a/lef/lefiKRDefs.hpp
+++ b/lef/lefiKRDefs.hpp
@@ -40,6 +40,12 @@
 
 #define LEF_ASSIGN_OPERATOR_H(cname) cname& operator=(const cname & prev)
 #define LEF_ASSIGN_OPERATOR_C(cname) cname& cname::operator=(const cname & prev)
+#define CHECK_SELF_ASSIGN                                               \
+{                                                                       \
+    if (this == &prev) {                                                \
+        return *this;                                                   \
+    }                                                                   \
+}
 
 #define LEF_COPY_FUNC(varname) {(varname) = prev.varname;}
 #define LEF_MALLOC_FUNC(varname, vartype, length)                           \

--- a/lef/lefiLayer.cpp
+++ b/lef/lefiLayer.cpp
@@ -366,6 +366,7 @@ LEF_COPY_CONSTRUCTOR_C(lefiParallel) {
 }
 
 LEF_ASSIGN_OPERATOR_C(lefiParallel) {
+    CHECK_SELF_ASSIGN
     this->Init();
     LEF_COPY_FUNC(numLength_);
     LEF_COPY_FUNC(numWidth_);
@@ -498,6 +499,7 @@ LEF_COPY_CONSTRUCTOR_C( lefiInfluence ) {
 }
 
 LEF_ASSIGN_OPERATOR_C( lefiInfluence ) {
+    CHECK_SELF_ASSIGN
     this->Init();
     LEF_COPY_FUNC(numAllocated_);
     LEF_COPY_FUNC(numWidth_);
@@ -783,6 +785,7 @@ LEF_COPY_CONSTRUCTOR_C( lefiSpacingTable ) {
 }
 
 LEF_ASSIGN_OPERATOR_C( lefiSpacingTable) {
+    CHECK_SELF_ASSIGN
     this->Init();
     LEF_COPY_FUNC( hasInfluence_ );
     LEF_MALLOC_FUNC_WITH_OPERATOR( influence_, lefiInfluence, sizeof(lefiInfluence));
@@ -947,11 +950,13 @@ LEF_COPY_CONSTRUCTOR_C( lefiOrthogonal ) {
 }
 
 LEF_ASSIGN_OPERATOR_C( lefiOrthogonal ) {
+    CHECK_SELF_ASSIGN
     this->Init();
     LEF_COPY_FUNC( numAllocated_ );
     LEF_COPY_FUNC( numCutOrtho_ );
     LEF_MALLOC_FUNC( cutWithin_, double, sizeof(double) * numCutOrtho_ );
     LEF_MALLOC_FUNC( ortho_, double, sizeof(double) * numCutOrtho_ ); 
+    return *this;
 }
 
 

--- a/lef/lefiMacro.cpp
+++ b/lef/lefiMacro.cpp
@@ -60,7 +60,9 @@ LEF_COPY_CONSTRUCTOR_C( lefiObstruction )
 }
 
 LEF_ASSIGN_OPERATOR_C ( lefiObstruction ) {
+    CHECK_SELF_ASSIGN
     LEF_MALLOC_FUNC( geometries_, lefiGeometries, sizeof(lefiGeometries)* 1 );
+    return *this;
 }
 
 
@@ -216,7 +218,7 @@ LEF_COPY_CONSTRUCTOR_C( lefiPinAntennaModel )
 }
 
 LEF_ASSIGN_OPERATOR_C( lefiPinAntennaModel ) {
-
+    CHECK_SELF_ASSIGN
     oxide_ = 0;
     antennaGateArea_ = 0;
     antennaGateAreaLayer_ = 0;
@@ -254,6 +256,7 @@ LEF_ASSIGN_OPERATOR_C( lefiPinAntennaModel ) {
     LEF_MALLOC_FUNC( antennaMaxCutCar_, double, sizeof(double) * numAntennaMaxCutCar_);
     // !!
     LEF_MALLOC_FUNC_FOR_2D_STR( antennaMaxCutCarLayer_, numAntennaMaxCutCar_ );
+    return *this;
 }
 
 lefiPinAntennaModel::~lefiPinAntennaModel()

--- a/lef/lefiMisc.cpp
+++ b/lef/lefiMisc.cpp
@@ -1193,7 +1193,7 @@ LEF_COPY_CONSTRUCTOR_C( lefiSite ) :
 }
 
 LEF_ASSIGN_OPERATOR_C( lefiSite ) {
-
+    CHECK_SELF_ASSIGN
     name_ = 0;
     siteNames_ = 0;
     siteOrients_ = 0;
@@ -1216,7 +1216,7 @@ LEF_ASSIGN_OPERATOR_C( lefiSite ) {
 
     LEF_MALLOC_FUNC_FOR_2D_STR ( siteNames_, numRowPattern_ );
     LEF_MALLOC_FUNC( siteOrients_, int, sizeof(int) * numRowPattern_ );
-
+    return *this;
 }
 
 void

--- a/lef/lefiUnits.cpp
+++ b/lef/lefiUnits.cpp
@@ -90,6 +90,7 @@ LEF_COPY_CONSTRUCTOR_C( lefiUnits ) {
 }
 
 LEF_ASSIGN_OPERATOR_C( lefiUnits ) {
+    CHECK_SELF_ASSIGN
     LEF_COPY_FUNC( hasDatabase_ );
     LEF_COPY_FUNC( hasCapacitance_ );
     LEF_COPY_FUNC( hasResistance_ );
@@ -108,6 +109,7 @@ LEF_ASSIGN_OPERATOR_C( lefiUnits ) {
     LEF_COPY_FUNC( current_ );
     LEF_COPY_FUNC( voltage_ );
     LEF_COPY_FUNC( frequency_ );
+    return *this;
 }
 
 void

--- a/lef/lefiVia.cpp
+++ b/lef/lefiVia.cpp
@@ -111,6 +111,7 @@ LEF_COPY_CONSTRUCTOR_C(lefiViaLayer)
 }
 
 LEF_ASSIGN_OPERATOR_C(lefiViaLayer) {
+    CHECK_SELF_ASSIGN
 //    printf("lefiViaLayer ASSIGN OPERATOR!\n");
 //    fflush(stdout);
     this->Init();


### PR DESCRIPTION
The optimizations lead to segmentation faults. Since the parsing of
lef/def files is not a bottleneck for the project, removing them should
not impact runtime.